### PR TITLE
Port bionic beaver

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -1,27 +1,18 @@
 FROM ghifari160/apache:16.04
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL MAINTAINER "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive functions
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update && \
 
-# Install git
-    apt install -y git git-man less libbsd0 libedit2 \
-        liberror-perl libpopt0 libx11-6 libx11-data libxau6 libxcb1 \
-        libxdmcp6 libxext6 libxmuu1 openssh-client patch rsync xauth make && \
+# Install Git and Make
+    apt install -y git make && \
 
 # Install build prerequisite
-    apt install -y autoconf automake autotools-dev binutils \
-        build-essential bzip2 cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc \
-        gcc-5 libalgorithm-diff-perl libalgorithm-diff-xs-perl \
-        libalgorithm-merge-perl libasan2 libatomic1 libc-dev-bin \
-        libc6-dev libcc1-0 libcilkrts5 libdpkg-perl libfakeroot \
-        libfile-fcntllock-perl libgcc-5-dev libgomp1 libisl15 libitm1 liblsan0 \
-        libltdl-dev libltdl7 libmpc3 libmpfr4 libmpx0 libquadmath0 libsigsegv2 \
-        libstdc++-5-dev libtool libtsan0 libubsan0 linux-libc-dev m4 manpages \
-        manpages-dev re2c icu-devtools libicu-dev libxml2-dev apache2-dev && \
+    apt install -y autoconf automake libtool gcc g++ build-essential \
+        libxml2-dev apache2-dev && \
 
 # Build and install Bison v2.7
     wget http://ftp.gnu.org/pub/gnu/bison/bison-2.7.tar.gz -O bison-2.7.tar.gz && \
@@ -43,12 +34,11 @@ RUN apt update && \
     rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
 
 # Uninstall build prerequisites
-  apt remove --autoremove -y autoconf automake autotools-dev binutils \
-    build-essential bzip2 cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc gcc-5 m4 \
-    manpages manpages-dev re2c icu-devtools libicu-dev libxml2-dev apache2-dev && \
+    apt remove --autoremove -y autoconf automake libtool gcc g++ \
+        build-essential libxml2-dev apache2-dev && \
 
-# Uninstall git
-  apt remove --autoremove -y git less patch && \
+# Uninstall Git and Make
+    apt remove --autoremove -y git make && \
 
 # Clean up APT
     apt clean && rm -rf /var/lib/apt/lists/* && \
@@ -56,7 +46,7 @@ RUN apt update && \
 # Configure PHP
     wget https://gist.githubusercontent.com/Ghifari160/bc9a6b56a12706bfeb1292380347cc51/raw/php.ini -O /usr/local/lib/php.ini && \
 
-# Configure Apache2
+# Configure Apache2 mod-php
     wget https://gist.githubusercontent.com/Ghifari160/a5c8778c192c34363178a9dc065029f3/raw/php.conf -O /etc/apache2/conf-available/php.conf && \
     a2enconf php
 

--- a/17.10/Dockerfile
+++ b/17.10/Dockerfile
@@ -1,27 +1,18 @@
 FROM ghifari160/apache:17.10
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL MAINTAINER "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive functions
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update && \
 
-# Install git
-    apt install -y git git-man less libbsd0 libedit2 \
-        liberror-perl libpopt0 libx11-6 libx11-data libxau6 libxcb1 \
-        libxdmcp6 libxext6 libxmuu1 openssh-client patch rsync xauth make && \
+# Install Git and Make
+    apt install -y git make && \
 
 # Install build prerequisite
-    apt install -y autoconf automake autotools-dev binutils \
-        build-essential bzip2 cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc \
-        gcc-5 libalgorithm-diff-perl libalgorithm-diff-xs-perl \
-        libalgorithm-merge-perl libasan2 libatomic1 libc-dev-bin \
-        libc6-dev libcc1-0 libcilkrts5 libdpkg-perl libfakeroot \
-        libfile-fcntllock-perl libgcc-5-dev libgomp1 libisl15 libitm1 liblsan0 \
-        libltdl-dev libltdl7 libmpc3 libmpfr4 libmpx0 libquadmath0 libsigsegv2 \
-        libstdc++-5-dev libtool libtsan0 libubsan0 linux-libc-dev m4 manpages \
-        manpages-dev re2c icu-devtools libicu-dev libxml2-dev apache2-dev && \
+    apt install -y autoconf automake libtool gcc g++ build-essential \
+        libxml2-dev apache2-dev && \
 
 # Build and install Bison v2.7
     wget http://ftp.gnu.org/pub/gnu/bison/bison-2.7.tar.gz -O bison-2.7.tar.gz && \
@@ -43,12 +34,11 @@ RUN apt update && \
     rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
 
 # Uninstall build prerequisites
-    apt remove --autoremove -y autoconf automake autotools-dev binutils \
-      build-essential bzip2 cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc gcc-5 m4 \
-      manpages manpages-dev re2c icu-devtools libicu-dev libxml2-dev apache2-dev && \
+    apt remove --autoremove -y autoconf automake libtool gcc g++ \
+        build-essential libxml2-dev apache2-dev && \
 
-# Uninstall git
-    apt remove --autoremove -y git less patch && \
+# Uninstall Git and Make
+    apt remove --autoremove -y git make && \
 
 # Clean up APT
     apt clean && rm -rf /var/lib/apt/lists/* && \
@@ -56,7 +46,7 @@ RUN apt update && \
 # Configure PHP
     wget https://gist.githubusercontent.com/Ghifari160/bc9a6b56a12706bfeb1292380347cc51/raw/php.ini -O /usr/local/lib/php.ini && \
 
-# Configure Apache2
+# Configure Apache2 mod-php
     wget https://gist.githubusercontent.com/Ghifari160/a5c8778c192c34363178a9dc065029f3/raw/php.conf -O /etc/apache2/conf-available/php.conf && \
     a2enconf php
 

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -1,0 +1,55 @@
+FROM ghifari160/apache:18.04
+
+LABEL maintainer "Ghifari160 <ghifari160@ghifari160.com>"
+
+# Disable interactive functions
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update && \
+
+# Install Git and Make
+    apt install -y git make && \
+
+# Install build prerequisite
+    apt install -y autoconf automake libtool gcc g++ build-essential \
+        libxml2-dev apache2-dev && \
+
+# Build and install Bison v2.7
+    wget http://ftp.gnu.org/pub/gnu/bison/bison-2.7.tar.gz -O bison-2.7.tar.gz && \
+    tar -xvzf bison-2.7.tar.gz && cd /bison-2.7 && ./configure \
+        --prefix=/usr/local/bison \
+        --with-libiconv-prefix=/usr/local/libiconv && \
+    make && make install && export PATH=$PATH:/usr/local/bison/bin && \
+
+# Download PHP v5.5.38 source code
+    cd / && \
+    git clone -b PHP-5.5.38 --single-branch https://github.com/php/php-src.git && \
+
+# Build and install PHP v5.5.38
+    cd /php-src && ./buildconf --force && \
+    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts && \
+    make && make install && \
+
+# Clean up build environment
+    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
+
+# Uninstall build prerequisites
+    apt remove --autoremove -y autoconf automake libtool gcc g++ \
+        build-essential libxml2-dev apache2-dev && \
+
+# Uninstall Git and Make
+    apt remove --autoremove -y git make && \
+
+# Clean up APT
+    apt clean && rm -rf /var/lib/apt/lists/* && \
+
+# Configure PHP
+    wget https://gist.githubusercontent.com/Ghifari160/bc9a6b56a12706bfeb1292380347cc51/raw/php.ini -O /usr/local/lib/php.ini && \
+
+# Configure Apache2 mod-php
+    wget https://gist.githubusercontent.com/Ghifari160/a5c8778c192c34363178a9dc065029f3/raw/php.conf -O /etc/apache2/conf-available/php.conf && \
+    a2enconf php
+
+# Add the custom default page
+RUN rm /var/www/html/index.html
+ADD index.php /var/www/html/index.php

--- a/18.04/index.php
+++ b/18.04/index.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-16.04/Dockerfile
+18.04/Dockerfile

--- a/README.md
+++ b/README.md
@@ -4,13 +4,20 @@
 
 This image is not just another PHP5.5 image for Docker.
 
+Looking for a PHP5.6 image for Docker? Checkout [ghifari160/apache-php56]!
+
 ## Why use this image ##
 This image is based on [ghifari160/apache], which forces Apache to run in the
 foreground and output its log into the container's stdio.
 
-__Note:__ PHP5.5 has reached its End of Life, it should not be used on a
-production environment. This image utilizes PHP5.5.38. The use of this image
-on a production server is ill advised. __*Use at your own risk.*__
+### Warnings ###
+- PHP5.5 has reached its End of Life, it should not be used on a
+  production environment. This image utilizes PHP5.5.38. The use of this image
+  on a production server is ill advised. __*Use at your own risk.*__
+- Reliable PHP5.5 binaries are no longer available on any package manager. This
+  image builds PHP5.5 binaries during the build process. Build tools and their
+  dependencies are installed purely to build the binaries. They are removed
+  after the binaries are built, installed, and configured.
 
 ## Installation ##
 By default this image should be run as a daemon.
@@ -43,10 +50,24 @@ another port on the host computer. Example:
 docker run -d -p 8080:80 ghifari160/apache-php55
 ```
 
+#### macOS permission fixes
+On macOS, shared volumes remains owned by the host user and group. Permissions
+on these shared volumes are also determined by the host, unchangeable from
+guest. On the home directory, the default owner and permission are
+`<user>:staff` and `755`. Apache needs write access to its files and
+directories. A workaround is to set the `www-data` UID and GID to `1000` and
+`50`. The init script will do this if the value of `G16_MACOS` is `yes`. Use
+the parameter `-e G16_MACOS=yes` to enable this workaround. Example:
+```
+docker run -d -e G16_MACOS=yes ghifari160/apache-php55
+```
+
 ## Tags ##
 | Tags                      | Ubuntu Version | Size  |
-|---------------------------|----------------|-------|
-| `latest` `16.04` `xenial` | 16.04          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php55.svg)](https://microbadger.com/images/ghifari160/apache-php55 "Get your own image badge on microbadger.com") |
-| `17.10` `artful`          | 17.10          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php55:17.10.svg)](https://microbadger.com/images/ghifari160/apache-php55:17.10 "Get your own image badge on microbadger.com") |
+|---------------------------|----------------|:-----:|
+| `16.04` `xenial`          | 16.04          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php55:16.04.svg)](https://microbadger.com/images/ghifari160/apache-php55:16.04 "Get your own image badge on microbadger.com")|
+| `17.10` `artful`          | 17.10          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php55:17.10.svg)](https://microbadger.com/images/ghifari160/apache-php55:17.10 "Get your own image badge on microbadger.com")|
+| `latest` `18.04` `bionic` | 18.04          |[![](https://images.microbadger.com/badges/image/ghifari160/apache-php55.svg)](https://microbadger.com/images/ghifari160/apache-php55 "Get your own image badge on microbadger.com")|
 
 [ghifari160/apache]: https://github.com/ghifari160/docker-apache
+[ghifari160/apache-php56]: https://github.com/ghifari160/docker-apache-php56

--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-16.04/index.php
+18.04/index.php


### PR DESCRIPTION
Ubuntu 18.04 LTS was released. It's time to port Apache2 and PHP5.5 on Ubuntu 18.04 LTS to Docker.