### PR TITLE
Enable MySQLi

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -31,8 +31,17 @@ RUN apt update && \
                 --with-mysqli && \
     make && make install && \
 
+# Build and install Xdebug
+    cd / && \
+    wget https://xdebug.org/files/xdebug-2.5.5.tgz -O xdebug.tar.gz && \
+    tar -xvzf xdebug.tar.gz && cd /xdebug-2.5.5 && \
+    phpize && \
+    ./configure --enable-xdebug && \
+    make && make install && \
+
 # Clean up build environment
-    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
+    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz /xdebug-2.5.5/* \
+           /xdebug.tar.gz && \
 
 # Uninstall build prerequisites
     apt remove --autoremove -y autoconf automake libtool gcc g++ \

--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -27,7 +27,8 @@ RUN apt update && \
 
 # Build and install PHP v5.5.38
     cd /php-src && ./buildconf --force && \
-    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts && \
+    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts \
+                --with-mysqli && \
     make && make install && \
 
 # Clean up build environment

--- a/17.10/Dockerfile
+++ b/17.10/Dockerfile
@@ -31,8 +31,17 @@ RUN apt update && \
                 --with-mysqli && \
     make && make install && \
 
+# Build and install Xdebug
+    cd / && \
+    wget https://xdebug.org/files/xdebug-2.5.5.tgz -O xdebug.tar.gz && \
+    tar -xvzf xdebug.tar.gz && cd /xdebug-2.5.5 && \
+    phpize && \
+    ./configure --enable-xdebug && \
+    make && make install && \
+
 # Clean up build environment
-    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
+    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz /xdebug-2.5.5/* \
+           /xdebug.tar.gz && \
 
 # Uninstall build prerequisites
     apt remove --autoremove -y autoconf automake libtool gcc g++ \

--- a/17.10/Dockerfile
+++ b/17.10/Dockerfile
@@ -27,7 +27,8 @@ RUN apt update && \
 
 # Build and install PHP v5.5.38
     cd /php-src && ./buildconf --force && \
-    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts && \
+    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts \
+                --with-mysqli && \
     make && make install && \
 
 # Clean up build environment

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -31,8 +31,17 @@ RUN apt update && \
                 --with-mysqli && \
     make && make install && \
 
+# Build and install Xdebug
+    cd / && \
+    wget https://xdebug.org/files/xdebug-2.5.5.tgz -O xdebug.tar.gz && \
+    tar -xvzf xdebug.tar.gz && cd /xdebug-2.5.5 && \
+    phpize && \
+    ./configure --enable-xdebug && \
+    make && make install && \
+
 # Clean up build environment
-    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz && \
+    rm -rf /php-src/* /bison-2.7/* /bison-2.7.tar.gz /xdebug-2.5.5/* \
+           /xdebug.tar.gz && \
 
 # Uninstall build prerequisites
     apt remove --autoremove -y autoconf automake libtool gcc g++ \

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -27,7 +27,8 @@ RUN apt update && \
 
 # Build and install PHP v5.5.38
     cd /php-src && ./buildconf --force && \
-    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts && \
+    ./configure --with-apxs2=/usr/bin/apxs2 --enable-maintainer-zts \
+                --with-mysqli && \
     make && make install && \
 
 # Clean up build environment


### PR DESCRIPTION
PHP5.5 does not build with MySQLi by default. MySQLi in this image is
configured to use mysqlnd.

- Add --with-mysqli parameter to PHP's ./configure build step